### PR TITLE
Use /tmp (accepted by default) for a tmp dir in macOS

### DIFF
--- a/engines/docker.js
+++ b/engines/docker.js
@@ -31,12 +31,12 @@ module.exports = ({id, code, stdinStream}) => new Promise((rootResolve) => {
 	const deferred = new Deferred();
 
 	(async () => {
+		const tmpOption = { unsafeCleanup: true };
+		if (process.platform === 'darwin') {
+			Object.assign(tmpOption, { dir: '/tmp' });
+		}
 		const {tmpPath, cleanup} = await new Promise((resolve, reject) => {
-			tmp.dir(
-				{
-					unsafeCleanup: true,
-				},
-				(error, dTmpPath, dCleanup) => {
+			tmp.dir(tmpOption, (error, dTmpPath, dCleanup) => {
 					if (error) {
 						reject(error);
 					} else {


### PR DESCRIPTION
macOS の Docker Desktop では、使用するディレクトリを予め指定しておかなければいけません。
デフォルトでは `/Users`, `/Volumes`,  `/private`, `/tmp` が指定されています。

元のコードでは tmp モジュールのデフォルト通り、`/var/folders` 以下に作成されることになっています。
しかしこれでは Docker Desktop で Preferences → File Sharing タブから `/var/folders` ディレクトリを登録する必要があり面倒であることから、macOS では `/tmp` を使うようにするオプションを設定しました。